### PR TITLE
debug: solve CI failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          key: ${{ runner.os }}-${{ matrix.platform.target }}-manylinux
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -99,6 +102,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          key: ${{ runner.os }}-${{ matrix.platform.target }}-musllinux
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -129,6 +135,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          key: ${{ runner.os }}-${{ matrix.platform.target }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -159,6 +168,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          key: ${{ runner.os }}-${{ matrix.platform.target }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -180,6 +192,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          key: ${{ runner.os }}-sdist
       - name: Build sdist
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:


### PR DESCRIPTION
the last PR #2 introduced a CI failure

The GLIBC error message pointed to the source as regular manylinux (glibc) vs. musllinux (musl libc). Isolate them using separate cache keys despite common build arch to fix